### PR TITLE
Allows setting RAILS_ENV environment variable during deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .capistrano
 stuff
 .DS_Store
+log
 *.pem

--- a/Capfile
+++ b/Capfile
@@ -7,6 +7,10 @@ require 'capistrano/setup'
 # Include default deployment tasks
 require 'capistrano/deploy'
 
+# Added per advice of deprecation notice
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
 # Include tasks from other gems included in your Gemfile
 #
 # For documentation on these, see for example:

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,6 @@
 # 'openvault' or 'AAPB'
 set :application, ENV['APP_NAME']
 set :repo_url, ENV['REPO_URL']
-set :rails_env, 'production'
 set :shared_path, "/var/www/#{ENV['APP_NAME']}/shared"
 
 if ENV['BRANCH'] && ENV['BRANCH'].length > 0
@@ -27,7 +26,7 @@ end
 
 # Add the path to bundler, /home/ec2-user/bin, to $PATH env var.
 set :linked_dirs, fetch(:linked_dirs, []).push('tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'tmp/downloads', 'jetty')
-set :rails_env, :production
+set :rails_env, ENV.fetch('RAILS_ENV', 'production')
 set :default_env, { 'PATH' => '$PATH:/home/ec2-user/bin' }
 set :bundle_flags, '--deployment'
 set :keep_releases, 1
@@ -39,12 +38,18 @@ verify_git_status!
 set :linked_dirs, fetch(:linked_dirs, []).push('log')
 namespace :deploy do
 
+  # Print relevant info prior to deployment
+  before 'deploy:starting', :print_info do
+    on roles(:all) do
+      info "Deploying branch: #{fetch(:branch)}"
+    end
+  end
+
   after :published, :ensure_jetty_is_installed do
     invoke 'jetty:install'
   end
 
   if ENV['APP_NAME'] == 'aapb'
-
     after :updated, :set_passenger_path do
       invoke 'deploy:config:remove_duplicate_passenger'
     end

--- a/deploy
+++ b/deploy
@@ -17,7 +17,7 @@ or passed in on the command line."
 IMAGE_NAME=aapb-deploy
 
 VOLUME_MOUNT="-v `pwd`:/root/"
-DOCKER_ARGS="docker run -it $VOLUME_MOUNT"
+DOCKER_ARGS="docker run -it --rm $VOLUME_MOUNT"
 
 
 if [ $1 = "build" -o $1 = "b" ]; then

--- a/lib/capistrano/tasks/revision.rake
+++ b/lib/capistrano/tasks/revision.rake
@@ -1,3 +1,4 @@
+# Usage: bundle exec cap aws revision
 desc 'Print the current Git revision'
 task :revision do
   on roles(:web) do


### PR DESCRIPTION
Also,
* Removes logs from revision.
* Requires capistrano git plugin and install it, per advice of deprecation notice.
* Add usage comment for `bundle exec cap aws revision` for fetching currently deployed revision.

Closes #87 .